### PR TITLE
Update pa11y-webservice to use pa11y 5.x

### DIFF
--- a/model/result.js
+++ b/model/result.js
@@ -167,18 +167,18 @@ module.exports = function(app, callback) {
 			convertPa11y2Results: function(results) {
 				var resultObject = {
 					count: {
-						total: results.length,
-						error: results.filter(function(result) {
+						total: results.issues.length,
+						error: results.issues.filter(function(result) {
 							return (result.type === 'error');
 						}).length,
-						warning: results.filter(function(result) {
+						warning: results.issues.filter(function(result) {
 							return (result.type === 'warning');
 						}).length,
-						notice: results.filter(function(result) {
+						notice: results.issues.filter(function(result) {
 							return (result.type === 'notice');
 						}).length
 					},
-					results: results
+					results: results.issues
 				};
 				return resultObject;
 			}

--- a/model/task.js
+++ b/model/task.js
@@ -163,6 +163,8 @@ module.exports = function(app, callback) {
 					}
 					var pa11yOptions = {
 						standard: task.standard,
+						includeWarnings: task.includeWarnings === false ? false : true,
+						includeNotices: task.includeNotices === false ? false : true,
 						timeout: (task.timeout || 30000),
 						wait: (task.wait || 0),
 						ignore: task.ignore,
@@ -171,6 +173,7 @@ module.exports = function(app, callback) {
 						log: {
 							debug: pa11yLog,
 							error: pa11yLog,
+							info: pa11yLog,
 							log: pa11yLog
 						}
 					};
@@ -182,7 +185,8 @@ module.exports = function(app, callback) {
 							}
 						};
 					}
-					if (task.headers && typeof task.headers === 'object') {
+					if (task.headers && typeof task.headers === 'object' &&
+					Object.keys(task.headers).length > 0) {
 						if (pa11yOptions.page) {
 							pa11yOptions.page.headers = task.headers;
 						} else {
@@ -198,12 +202,13 @@ module.exports = function(app, callback) {
 					async.waterfall([
 
 						function(next) {
-							try {
-								var test = pa11y(pa11yOptions);
-								test.run(task.url, next);
-							} catch (error) {
-								return next(error);
-							}
+							pa11y(task.url, pa11yOptions)
+								.then(function(results) {
+									next(null, results);
+								})
+								.catch(function(error) {
+									next(error);
+								});
 						},
 
 						function(results, next) {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "pa11y-webservice",
-  "version": "2.3.1",
+  "version": "3.0.0",
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "description": "Pa11y Webservice provides scheduled accessibility reports for multiple URLs",
   "keywords": [
@@ -29,7 +29,7 @@
     "hapi": "~12.1",
     "joi": "~6.10",
     "mongodb": "~2.1",
-    "pa11y": "^4.13.2",
+    "pa11y": "^5.0.3",
     "underscore": "~1.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Implements #56 

A couple of notes:
1) This is a major version upgrade because the response from pa11y has changed and how the results are parsed is a backwards-incompatible change.
2) pa11y 5.x's default behavior of not showing warnings or notices deviates from 4.x, so the defaults in pa11y-webservice have these defaulted to true.
3) There were already-failing unit tests in the test suite prior to these changes.  These changes have not changed the results of the tests.

If this gets accepted, I'll submit another PR for pa11y-dashboard to upgrade to pa11y-webservice 3.x.