### PR TITLE
Improve error message when starting webservice without Mongodb running

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pa11y Webservice provides scheduled accessibility reports for multiple URLs. It 
 Setup
 -----
 
-Pa11y Webservice requires [Node.js][node] 4+ and [PhantomJS][phantom]. See the [Pa11y documentation][pa11y-docs] for more information on these dependencies. Pa11y Webservice also requires [MongoDB][mongo] to be installed and running.
+Pa11y Webservice requires [Node.js][node] 4+ and [PhantomJS][phantom]. See the [Pa11y documentation][pa11y-docs] for more information on these dependencies. Pa11y Webservice also requires [MongoDB][mongo] to be installed and running.  Instructions for installing Mongo are available on their website, but for simple use-cases, installing Mongo using your OS package manager such as `brew install mongodb` or `apt-get install mongodb` is likely to be sufficient.
 
 You'll then need to clone this repo locally and install dependencies with `npm install`. Now we need to add some configuration before we can run the application. We can do this in two ways:
 

--- a/app.js
+++ b/app.js
@@ -40,6 +40,9 @@ function initApp(config, callback) {
 			/* eslint camelcase: 'off' */
 			MongoClient.connect(config.database, {server: {auto_reconnect: false}}, function(error, db) {
 				app.db = db;
+				if (error) {
+					console.error('Error: Unable to connect to MongoDB: ' + error.message);
+				}
 				next(error);
 			});
 		},


### PR DESCRIPTION
I found it a bit hard to debug getting the webservice started, so added a bit more instructions and diagnostics.