### PR TITLE
Add debugging info to startup log

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@
 'use strict';
 
 var chalk = require('chalk');
-var env = (process.env.NODE_ENV || 'development');
 var config = require('./config');
 
 process.on('SIGINT', function() {
@@ -26,8 +25,10 @@ process.on('SIGINT', function() {
 require('./app')(config, function(error, app) {
 	console.log('');
 	console.log(chalk.underline.cyan('Pa11y Webservice started'));
-	console.log(chalk.grey('mode: %s'), env);
-	console.log(chalk.grey('uri:  %s'), app.server.info.uri);
+	console.log(chalk.grey('mode:     %s'), process.env.NODE_ENV);
+	console.log(chalk.grey('uri:      %s'), app.server.info.uri);
+	console.log(chalk.grey('database: %s'), config.database);
+	console.log(chalk.grey('cron:     %s'), config.cron);
 
 	if (error) {
 		console.error('');


### PR DESCRIPTION
There are two ways of setting a configuration for this app: config files, and environment variables. This makes it easy for the app to run with a different config from the one that you intend to run it with.

Currently, only the `NODE_ENV` variable and server url are being printed out on startup:

![screen shot 2019-01-17 at 18 09 10](https://user-images.githubusercontent.com/1792637/51338968-2547a100-1a83-11e9-9fe4-0ce65e2b3915.png)

This PR adds the database config and the cron config to the details being displayed. This may help debug configuration issues, database issues, and specially making easier to understand what config is being used when for example running in a container.

![screen shot 2019-01-17 at 18 09 40](https://user-images.githubusercontent.com/1792637/51338983-2bd61880-1a83-11e9-9937-d6418c3ae08f.png)

The app was also defaulting to display `development` as the `NODE_ENV` when no environment has been set, I've removed this for consistency with pa11y-dashboard where we will display `undefined` when this is not set.