### PR TITLE
Use namespaced deps and bump versions

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const async = require('async');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const MongoClient = require('mongodb').MongoClient;
 
 module.exports = initApp;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@hapi/hapi": "~17.9.0",
     "@hapi/joi": "~15.0.3",
     "mongodb": "~2.2.19",
-    "pa11y": "^5.1.0",
+    "pa11y": "~5.1.0",
     "underscore": "~1.9.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,21 +23,21 @@
   "bugs": "https://github.com/pa11y/webservice/issues",
   "license": "GPL-3.0",
   "dependencies": {
-    "async": "~2.6",
-    "chalk": "~2.4",
-    "cron": "~1.7",
-    "hapi": "~17.0",
-    "joi": "~14.3",
+    "async": "~2.6.2",
+    "chalk": "~2.4.2",
+    "cron": "~1.7.1",
+    "@hapi/hapi": "~17.9.0",
+    "@hapi/joi": "~15.0.3",
     "mongodb": "~2.2.19",
     "pa11y": "^5.1.0",
-    "underscore": "~1.9"
+    "underscore": "~1.9.1"
   },
   "devDependencies": {
     "eslint": "^5.16.0",
-    "mocha": "^6",
+    "mocha": "^6.1.4",
     "pa11y-lint-config": "^1.2.1",
-    "proclaim": "^3",
-    "request": "^2"
+    "proclaim": "^3.6.0",
+    "request": "^2.88.0"
   },
   "main": "./app.js",
   "scripts": {


### PR DESCRIPTION
* Update `hapi` and `joi` to use the new namespaced packages (i.e. `@hapi/hapi` and `@hapi/joi`). This removes a bunch of warnings when doing `npm install`
* Make all version numbers in the form X.Y.Z so they are consistent and predictable
* Minor updates to a few deps