### PR TITLE
Webservice doesnt starup

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,10 +87,16 @@ function initApp(config, callback) {
 			if (config.dbOnly) {
 				return next();
 			}
+
 			require('./route/index')(app);
 			require('./route/tasks')(app);
 			require('./route/task')(app);
-			app.server.start(next);
+
+			app.server.start()
+				.then(
+					() => next(),
+					error => next(error)
+				);
 
 			console.log(`Server running at: ${app.server.info.uri}`);
 		}

--- a/app.js
+++ b/app.js
@@ -34,13 +34,15 @@ function initApp(config, callback) {
 	};
 
 	async.series([
-
 		function(next) {
 			/* eslint camelcase: 'off' */
-			MongoClient.connect(config.database, {server: {auto_reconnect: false}}, function(error, db) {
+			MongoClient.connect(config.database, {
+				autoReconnect: true
+			}, function(error, db) {
 				if (error) {
 					console.log('Error connecting to MongoDB:');
 					console.log(JSON.stringify(error));
+					return next(error);
 				}
 
 				db.on('timeout', () => {

--- a/data/fixture/load.js
+++ b/data/fixture/load.js
@@ -29,21 +29,27 @@ function loadFixtures(env, config, done) {
 
 	application(config, async function(error, app) {
 		if (error) {
+			return done(error);
+		}
+
+		try {
+			// Clear existing content
+			await app.model.result.collection.remove();
+			await app.model.task.collection.remove();
+
+			// Insert new content
+			await Promise.all(fixtures.tasks.map(function(task) {
+				return app.model.task.create(task);
+			}));
+			await Promise.all(fixtures.results.map(function(result) {
+				return app.model.result.create(result);
+			}));
+
+			await app.db.close();
+			done();
+			// eslint-disable-next-line no-shadow,no-catch-shadow
+		} catch (error) {
 			done(error);
 		}
-		// Clear existing content
-		await app.model.result.collection.remove();
-		await app.model.task.collection.remove();
-
-		// Insert new content
-		await Promise.all(fixtures.tasks.map(function(task) {
-			return app.model.task.create(task);
-		}));
-		await Promise.all(fixtures.results.map(function(result) {
-			return app.model.result.create(result);
-		}));
-
-		await app.db.close();
-		done();
 	});
 }

--- a/route/task.js
+++ b/route/task.js
@@ -17,7 +17,7 @@
 'use strict';
 
 const chalk = require('chalk');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const validateAction = require('pa11y').isValidAction;
 
 // Routes relating to individual tasks

--- a/route/tasks.js
+++ b/route/tasks.js
@@ -17,7 +17,7 @@
 'use strict';
 
 const _ = require('underscore');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const validateAction = require('pa11y').isValidAction;
 
 // Routes relating to all tasks

--- a/test/integration/create-task.js
+++ b/test/integration/create-task.js
@@ -30,11 +30,13 @@ describe('POST /tasks', function() {
 				standard: 'WCAG2AA',
 				ignore: ['foo', 'bar']
 			};
+
 			const request = {
 				method: 'POST',
 				endpoint: 'tasks',
 				body: newTask
 			};
+
 			this.navigate(request, done);
 		});
 

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -24,15 +24,15 @@ const request = require('request');
 before(function(done) {
 	const that = this;
 
-	that.baseUrl = 'http://localhost:' + config.port + '/';
-	that.app = null;
-	that.last = {};
-	that.navigate = createNavigator(that.baseUrl, that.last);
+	this.baseUrl = 'http://localhost:' + config.port + '/';
+	this.app = null;
+	this.last = {};
+	this.navigate = createNavigator(that.baseUrl, that.last);
 
-	assertTestAppIsRunning(that.baseUrl, function() {
+	assertTestAppIsRunning(this.baseUrl, function() {
 		config.dbOnly = true;
-		app(config, function(error, app) {
-			that.app = app;
+		app(config, function(error, initialisedApp) {
+			that.app = initialisedApp;
 			loadFixtures('test', config, done);
 		});
 	});

--- a/test/integration/startup.js
+++ b/test/integration/startup.js
@@ -1,0 +1,41 @@
+// This file is part of Pa11y Webservice.
+//
+// Pa11y Webservice is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Pa11y Webservice is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Pa11y Webservice.  If not, see <http://www.gnu.org/licenses/>.
+'use strict';
+
+const assert = require('proclaim');
+const config = require('../../config/test.json');
+const app = require('../../app');
+
+describe('pa11y-service startup', function() {
+
+	it('should start the service and call the callback', done => {
+		const modifiedConfig = {
+			database: config.database,
+			host: config.host,
+			port: config.port + 10
+		};
+
+		app(modifiedConfig, (error, webservice) => {
+			assert.isNull(error);
+			assert.notStrictEqual(webservice, undefined);
+
+			webservice.server.stop();
+
+			done();
+		});
+	});
+});
+
+


### PR DESCRIPTION
This PR adresses a number of issues with the webservices starting and error handling. Detailed in this issue #77 

- Wrong HAPI package was being used (whoops)
- No `try/catch` around new `await` code so errors were bubbling to the top of the stack (which will crash node in future versions
- The upgraded versino of `hapi` switched to a promise based API rather than callback, so the final `next` was not being called