### PR TITLE
Pa11y not run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 
 # Language/versions
 language: node_js
+
+dist: trusty
+addons:
+  apt:
+    packages:
+      # This is required to run new chrome on old trusty
+      - libnss3
+
 matrix:
   include:
     - node_js: '8'
@@ -15,6 +23,13 @@ branches:
 # Services setup
 services:
   - mongodb
+
+before_install:
+  # Enable user namespace cloning
+  - "sysctl kernel.unprivileged_userns_clone=1"
+  # Launch XVFB
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 
 # Build script
 before_script:

--- a/data/fixture/test/tasks.js
+++ b/data/fixture/test/tasks.js
@@ -40,5 +40,15 @@ module.exports = [
 		url: 'nature.com/news',
 		timeout: 30000,
 		standard: 'Section508'
+	},
+	{
+		_id: new ObjectID('abc000000000000000000004'),
+		name: 'Z Integration Test',
+		url: 'http://localhost:8132',
+		timeout: 30000,
+		standard: 'WCAG2AA',
+		username: 'user',
+		password: 'access',
+		ignore: ['foo', 'bar']
 	}
 ];

--- a/route/task.js
+++ b/route/task.js
@@ -154,6 +154,7 @@ module.exports = function(app) {
 					chalk.red('Failed to finish task %s'),
 					task.id
 				);
+				return reply.response(`Failed to finish task ${task.id}`).code(500);
 			}
 			console.log(
 				chalk.grey('Finished running one-off task @ %s'),

--- a/route/task.js
+++ b/route/task.js
@@ -143,24 +143,22 @@ module.exports = function(app) {
 			if (!task) {
 				return reply.response('Not Found').code(404);
 			}
-			if (process.env.NODE_ENV !== 'test') {
-				console.log('');
-				console.log(chalk.grey('Starting to run one-off task @ %s'), new Date());
-				console.log('Starting task %s', task.id);
-				const executed = await model.task.runById(request.params.id);
-				if (executed) {
-					console.log(chalk.green('Finished task %s'), task.id);
-				} else {
-					console.log(
-						chalk.red('Failed to finish task %s'),
-						task.id
-					);
-				}
+			console.log('');
+			console.log(chalk.grey('Starting to run one-off task @ %s'), new Date());
+			console.log('Starting task %s', task.id);
+			const executed = await model.task.runById(request.params.id);
+			if (executed) {
+				console.log(chalk.green('Finished task %s'), task.id);
+			} else {
 				console.log(
-					chalk.grey('Finished running one-off task @ %s'),
-					new Date()
+					chalk.red('Failed to finish task %s'),
+					task.id
 				);
 			}
+			console.log(
+				chalk.grey('Finished running one-off task @ %s'),
+				new Date()
+			);
 			return reply.response().code(202);
 		},
 		options: {

--- a/test/integration/get-all-tasks.js
+++ b/test/integration/get-all-tasks.js
@@ -36,7 +36,7 @@ describe('GET /tasks', function() {
 			const body = this.last.body;
 			const tasks = await this.app.model.task.getAll();
 			assert.isArray(body);
-			assert.strictEqual(body.length, 3);
+			assert.strictEqual(body.length, 4);
 			assert.deepEqual(body, tasks);
 		});
 
@@ -62,15 +62,22 @@ describe('GET /tasks', function() {
 		it('should output a JSON representation of all tasks including their last result', function(done) {
 			const body = this.last.body;
 			assert.isArray(body);
-			assert.strictEqual(body.length, 3);
+			assert.strictEqual(body.length, 4);
+
 			assert.strictEqual(body[0].id, 'abc000000000000000000001');
 			assert.isObject(body[0].last_result);
 			assert.strictEqual(body[0].last_result.id, 'def000000000000000000001');
+
 			assert.strictEqual(body[1].id, 'abc000000000000000000002');
 			assert.isObject(body[1].last_result);
 			assert.strictEqual(body[1].last_result.id, 'def000000000000000000002');
+
 			assert.strictEqual(body[2].id, 'abc000000000000000000003');
 			assert.strictEqual(body[2].last_result, null);
+
+			assert.strictEqual(body[3].id, 'abc000000000000000000004');
+			assert.strictEqual(body[3].last_result, null);
+
 			done();
 		});
 

--- a/test/integration/run-task-by-id.js
+++ b/test/integration/run-task-by-id.js
@@ -14,18 +14,40 @@
 // along with Pa11y Webservice.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
+const http = require('http');
 const assert = require('proclaim');
+
+const responseBody = `
+<!doctype html>
+<html>
+	<head>
+		<title>Integration Test</title>
+	</head>
+	<body>Content</body>
+</html>
+`;
 
 describe('POST /tasks/{id}/run', function() {
 
 	describe('with valid and existing task ID', function() {
+		let server;
 
 		beforeEach(function(done) {
+			server = http.createServer(function(request, response) {
+				response.writeHead(200, {'Content-Type': 'text/html'});
+				response.end(responseBody);
+			});
+			server.listen(8132);
+
 			const request = {
 				method: 'POST',
-				endpoint: 'tasks/abc000000000000000000001/run'
+				endpoint: 'tasks/abc000000000000000000004/run'
 			};
 			this.navigate(request, done);
+		});
+
+		afterEach(function(done) {
+			server.close(done);
 		});
 
 		it('should send a 202 status', function() {


### PR DESCRIPTION
The HAPI PR accidently broke how `pa11y` was being called. As there was no integration test this didn't ever get picked up. So this PR:

- Calls pa11y correctly.
- Removes the `.page` part of the options as thats outdated and should be done using `headers.
- Uses `headers` for HTTP Auth.
- Includes calling pa11y in the integration tests (there is only one that calls that endpoint).
- Return an HTTP 500 if running `pa11y` fails.