### PR TITLE
Set concurrency limit via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,11 @@ The boot configurations for Pa11y Webservice are as follows. Look at the sample 
 
 This configuration option isn't available when you're using environment variables. [Use a JSON configuration file](https://github.com/pa11y/pa11y-webservice#option-2-using-config-files) if you need to pass these parameters.
 
-## Contributing
+### numWorkers
+*(number)* The concurrency limit or number of workers that will be running concurrently on each cron execution. Set via a config file or the `NUM_WORKERS` environment variable.
+
+Contributing
+------------
 
 There are many ways to contribute to Pa11y Webservice, we cover these in the [contributing guide](CONTRIBUTING.md) for this repo.
 

--- a/config.js
+++ b/config.js
@@ -25,7 +25,8 @@ if (fs.existsSync(jsonPath)) {
 		host: env('HOST', jsonConfig.host),
 		port: Number(env('PORT', jsonConfig.port)),
 		cron: env('CRON', jsonConfig.cron),
-		chromeLaunchConfig: jsonConfig.chromeLaunchConfig || {}
+		chromeLaunchConfig: jsonConfig.chromeLaunchConfig || {},
+		numWorkers: jsonConfig.numWorkers || 2
 	};
 } else {
 	module.exports = {
@@ -33,7 +34,8 @@ if (fs.existsSync(jsonPath)) {
 		host: env('HOST', '0.0.0.0'),
 		port: Number(env('PORT', '3000')),
 		cron: env('CRON', false),
-		chromeLaunchConfig: {}
+		chromeLaunchConfig: {},
+		numWorkers: Number(env('NUM_WORKERS', '2'))
 	};
 }
 

--- a/task/pa11y.js
+++ b/task/pa11y.js
@@ -34,7 +34,6 @@ function initTask(config, app) {
 
 // Run the task
 function run(app) {
-
 	console.log('');
 	console.log(chalk.grey('Starting to run tasks @ %s'), new Date());
 
@@ -69,8 +68,7 @@ function runPa11yOnTasks(tasks, app, done) {
 			}
 			nextInQueue();
 		});
-
-	}, 2);
+	}, app.config.numWorkers);
 
 	queue.drain = () => {
 		console.log(chalk.grey('Finished running tasks @ %s'), new Date());

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -28,6 +28,7 @@ describe('config', () => {
 		host: 'config-file-host',
 		port: 1000,
 		cron: 'config-fille-cron',
+		numWorkers: 2,
 		chromeLaunchConfig: {
 			field: 'value'
 		}
@@ -65,6 +66,7 @@ describe('config', () => {
 				assert.strictEqual(config.host, mockConfig.host);
 				assert.strictEqual(config.port, mockConfig.port);
 				assert.strictEqual(config.cron, mockConfig.cron);
+				assert.strictEqual(config.numWorkers, mockConfig.numWorkers);
 				assert.deepEqual(config.chromeLaunchConfig, mockConfig.chromeLaunchConfig);
 			});
 
@@ -90,6 +92,7 @@ describe('config', () => {
 				assert.strictEqual(config.host, mockConfig.host);
 				assert.strictEqual(config.port, 2000);
 				assert.strictEqual(config.cron, mockConfig.cron);
+				assert.strictEqual(config.numWorkers, mockConfig.numWorkers);
 				assert.deepEqual(config.chromeLaunchConfig, mockConfig.chromeLaunchConfig);
 			});
 		});
@@ -118,6 +121,7 @@ describe('config', () => {
 				process.env.HOST = 'env-host-2';
 				process.env.PORT = '3000';
 				process.env.CRON = 'env-cron-2';
+				process.env.NUM_WORKERS = 4;
 			});
 
 			afterEach(() => {
@@ -135,6 +139,7 @@ describe('config', () => {
 				assert.strictEqual(config.host, 'env-host-2');
 				assert.strictEqual(config.port, 3000);
 				assert.strictEqual(config.cron, 'env-cron-2');
+				assert.strictEqual(config.numWorkers, 4);
 				assert.deepEqual(config.chromeLaunchConfig, {});
 			});
 		});


### PR DESCRIPTION
Currently, the concurrency limit for the cron job is set to 2 workers.
Since in some cases some users don't not need to use too many
resources and can get the job done wih only one worker,
this number could be set using an environment variable.