### PR TITLE
Display task id before each line of output

### DIFF
--- a/model/task.js
+++ b/model/task.js
@@ -183,8 +183,6 @@ module.exports = function(app, callback) {
 			// Run a task by ID
 			runById: function(id) {
 				return model.getById(id).then(async task => {
-					this.id = task.id;
-
 					const pa11yOptions = {
 						standard: task.standard,
 						includeWarnings: true,
@@ -196,10 +194,10 @@ module.exports = function(app, callback) {
 						chromeLaunchConfig: app.config.chromeLaunchConfig || {},
 						headers: task.headers || {},
 						log: {
-							debug: model.pa11yLog(),
-							error: model.pa11yLog(),
-							info: model.pa11yLog(),
-							log: model.pa11yLog()
+							debug: model.pa11yLog(task.id),
+							error: model.pa11yLog(task.id),
+							info: model.pa11yLog(task.id),
+							log: model.pa11yLog(task.id)
 						}
 					};
 
@@ -285,7 +283,9 @@ module.exports = function(app, callback) {
 				return headers;
 			},
 
-			pa11yLog: function() {
+			pa11yLog: function(id) {
+				this.id = id;
+
 				return message => {
 					let messageString;
 

--- a/model/task.js
+++ b/model/task.js
@@ -283,14 +283,12 @@ module.exports = function(app, callback) {
 				return headers;
 			},
 
-			pa11yLog: function(id) {
-				this.id = id;
-
+			pa11yLog: function(taskId) {
 				return message => {
 					let messageString;
 
-					if (this.id) {
-						messageString = `[${this.id}]  > ${message}`;
+					if (taskId) {
+						messageString = `[${taskId}]  > ${message}`;
 					} else {
 						messageString = `  > ${message}`;
 					}

--- a/model/task.js
+++ b/model/task.js
@@ -22,10 +22,6 @@ const chalk = require('chalk');
 const {ObjectID} = require('mongodb');
 const pa11y = require('pa11y');
 
-function pa11yLog(message) {
-	console.log(chalk.grey(`  > ${message}`));
-}
-
 // Task model
 module.exports = function(app, callback) {
 	app.db.collection('tasks', function(errors, collection) {
@@ -187,6 +183,8 @@ module.exports = function(app, callback) {
 			// Run a task by ID
 			runById: function(id) {
 				return model.getById(id).then(async task => {
+					this.id = task.id;
+
 					const pa11yOptions = {
 						standard: task.standard,
 						includeWarnings: true,
@@ -198,10 +196,10 @@ module.exports = function(app, callback) {
 						chromeLaunchConfig: app.config.chromeLaunchConfig || {},
 						headers: task.headers || {},
 						log: {
-							debug: pa11yLog,
-							error: pa11yLog,
-							info: pa11yLog,
-							log: pa11yLog
+							debug: model.pa11yLog(),
+							error: model.pa11yLog(),
+							info: model.pa11yLog(),
+							log: model.pa11yLog()
 						}
 					};
 
@@ -285,6 +283,20 @@ module.exports = function(app, callback) {
 					}
 				}
 				return headers;
+			},
+
+			pa11yLog: function() {
+				return message => {
+					let messageString;
+
+					if (this.id) {
+						messageString = `[${this.id}]  > ${message}`;
+					} else {
+						messageString = `  > ${message}`;
+					}
+
+					console.log(chalk.grey(messageString));
+				};
 			}
 
 		};


### PR DESCRIPTION
This change makes the task id available inside the log function, so each line of output can be displayed next to the id of the task it belongs to.

This solves the problem of not being able to tell to which task a line of output belongs to, as tasks run and output to the screen concurrently.

How it looks in action:

![image](https://user-images.githubusercontent.com/1792637/65155972-253edd00-da26-11e9-87a0-f2fccfdd3bc2.png)
