### PR TITLE
Add whitelist of files to be published on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "files": [
     "*.js",
-    "/model",
-    "/route",
-    "/task"
+    "model",
+    "route",
+    "task"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,11 @@
   "scripts": {
     "start": "node index.js",
     "test": "make ci"
-  }
+  },
+  "files": [
+    "*.js",
+    "/model",
+    "/route",
+    "/task"
+  ]
 }


### PR DESCRIPTION
This reduces the size of the package from 71.4 kB (1.6 MB unpacked) to 23.5 kB (81.9 kB unpacked).