### PR TITLE
Version 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 3.1.2 (2019-09-27)
+
+* Add data fixtures back, which are required by pa11y-dashboard to run its tests.
+
 ## 3.1.1 (2019-09-27)
 
 * Bump pa11y to 5.2.1, which fixes an issue with some sites failing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-webservice",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "engines": {
     "node": ">=8"
   },
@@ -46,6 +46,7 @@
   },
   "files": [
     "*.js",
+    "data",
     "model",
     "route",
     "task"


### PR DESCRIPTION
Add data fixtures back as they are required by pa11y-dashboard in order to run the integration tests.