### PR TITLE
Move mongo events from db class to client

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,6 +40,20 @@ function initApp(config, callback) {
 		useUnifiedTopology: true
 	});
 
+	// Mongo documentation states that events need to be defined before
+	//  connect() so we can be sure that we're capturing all the events
+	client.on('timeout', () => {
+		console.log('Mongo connection timeout');
+	});
+
+	client.on('close', () => {
+		console.log('Mongo connection closed');
+	});
+
+	client.on('reconnect', () => {
+		console.log('Mongo connection reestablished');
+	});
+
 	async.series([
 		next => {
 			/* eslint camelcase: 'off' */
@@ -50,19 +64,6 @@ function initApp(config, callback) {
 				app.client = client;
 				app.db = db;
 
-				db.on('timeout', () => {
-					console.log('Mongo connection timeout');
-				});
-
-				db.on('close', () => {
-					console.log('Mongo connection closed');
-				});
-
-				db.on('reconnect', () => {
-					console.log('Mongo reconnected');
-				});
-
-				app.db = db;
 				next(error);
 			});
 		},


### PR DESCRIPTION
Listening for events on the db class of the mongo client is now deprecated. The modern behaviour is to listen to events on the client class.

This PR fixes this behaviour and removes the deprecation warnings when starting webservice (and dashboard)
> (node:20551) DeprecationWarning: Listening to events on the Db class has been deprecated and will be removed in the next major version.

Additionally, the event listeners were set inside the connect() callback, which means that there was the potential for some of the events to be lost. We are now setting up the events before calling connect(), so we can be sure that we will capture all of them.