### PR TITLE
Validate all ids before they are sent to the DB

### DIFF
--- a/route/task.js
+++ b/route/task.js
@@ -54,6 +54,9 @@ module.exports = function(app) {
 		},
 		options: {
 			validate: {
+				params: Joi.object({
+					id: Joi.string().regex(/^[0-9a-fA-F]{24}$/)
+				}),
 				query: Joi.object({
 					lastres: Joi.boolean()
 				}),
@@ -89,6 +92,9 @@ module.exports = function(app) {
 		},
 		options: {
 			validate: {
+				params: Joi.object({
+					id: Joi.string().regex(/^[0-9a-fA-F]{24}$/)
+				}),
 				query: {},
 				payload: Joi.object({
 					name: Joi.string().required(),
@@ -127,6 +133,9 @@ module.exports = function(app) {
 		},
 		options: {
 			validate: {
+				params: Joi.object({
+					id: Joi.string().regex(/^[0-9a-fA-F]{24}$/)
+				}),
 				query: {},
 				payload: false
 			}
@@ -165,6 +174,9 @@ module.exports = function(app) {
 		},
 		options: {
 			validate: {
+				params: Joi.object({
+					id: Joi.string().regex(/^[0-9a-fA-F]{24}$/)
+				}),
 				query: {}
 			}
 		}
@@ -188,6 +200,9 @@ module.exports = function(app) {
 		},
 		options: {
 			validate: {
+				params: Joi.object({
+					id: Joi.string().regex(/^[0-9a-fA-F]{24}$/)
+				}),
 				query: Joi.object({
 					from: Joi.string().isoDate(),
 					to: Joi.string().isoDate(),
@@ -214,6 +229,10 @@ module.exports = function(app) {
 		},
 		options: {
 			validate: {
+				params: Joi.object({
+					tid: Joi.string().regex(/^[0-9a-fA-F]{24}$/),
+					rid: Joi.string().regex(/^[0-9a-fA-F]{24}$/)
+				}),
 				query: Joi.object({
 					full: Joi.boolean()
 				}),

--- a/test/integration/delete-task-by-id.js
+++ b/test/integration/delete-task-by-id.js
@@ -70,8 +70,8 @@ describe('DELETE /tasks/{id}', function() {
 			this.navigate(request, done);
 		});
 
-		it('should send a 404 status', function() {
-			assert.strictEqual(this.last.status, 404);
+		it('should send a 400 status', function() {
+			assert.strictEqual(this.last.status, 400);
 		});
 
 	});

--- a/test/integration/edit-task-by-id.js
+++ b/test/integration/edit-task-by-id.js
@@ -268,8 +268,8 @@ describe('PATCH /tasks/{id}', function() {
 			this.navigate(request, done);
 		});
 
-		it('should send a 404 status', function() {
-			assert.strictEqual(this.last.status, 404);
+		it('should send a 400 status', function() {
+			assert.strictEqual(this.last.status, 400);
 		});
 
 	});

--- a/test/integration/get-result-by-id.js
+++ b/test/integration/get-result-by-id.js
@@ -120,8 +120,8 @@ describe('GET /tasks/{id}/results/{id}', function() {
 				this.navigate(request, done);
 			});
 
-			it('should send a 404 status', function() {
-				assert.strictEqual(this.last.status, 404);
+			it('should send a 400 status', function() {
+				assert.strictEqual(this.last.status, 400);
 			});
 
 		});
@@ -170,8 +170,8 @@ describe('GET /tasks/{id}/results/{id}', function() {
 			this.navigate(request, done);
 		});
 
-		it('should send a 404 status', function() {
-			assert.strictEqual(this.last.status, 404);
+		it('should send a 400 status', function() {
+			assert.strictEqual(this.last.status, 400);
 		});
 
 	});

--- a/test/integration/get-results-by-task-id.js
+++ b/test/integration/get-results-by-task-id.js
@@ -160,8 +160,8 @@ describe('GET /tasks/{id}/results', function() {
 			this.navigate(request, done);
 		});
 
-		it('should send a 404 status', function() {
-			assert.strictEqual(this.last.status, 404);
+		it('should send a 400 status', function() {
+			assert.strictEqual(this.last.status, 400);
 		});
 
 	});

--- a/test/integration/get-task-by-id.js
+++ b/test/integration/get-task-by-id.js
@@ -101,8 +101,8 @@ describe('GET /tasks/{id}', function() {
 			this.navigate(request, done);
 		});
 
-		it('should send a 404 status', function() {
-			assert.strictEqual(this.last.status, 404);
+		it('should send a 400 status', function() {
+			assert.strictEqual(this.last.status, 400);
 		});
 
 	});

--- a/test/integration/run-task-by-id.js
+++ b/test/integration/run-task-by-id.js
@@ -82,8 +82,8 @@ describe('POST /tasks/{id}/run', function() {
 			this.navigate(request, done);
 		});
 
-		it('should send a 404 status', function() {
-			assert.strictEqual(this.last.status, 404);
+		it('should send a 400 status', function() {
+			assert.strictEqual(this.last.status, 400);
 		});
 
 	});


### PR DESCRIPTION
Until now, ids passed in a request were not validated by webservice, but were instead sent directly to the database layer for retrieval, relying on the database code to return an appropriate error that would then cause webservice to return a 404.

This was the root cause for all the numerous "ObjectID generation failed" errors happening on pa11y dashboard.

This commit changes this behaviour so all requests made to webservice containing database ids will have those ids validated using joi before they are used in database queries. All queries received with an id in an invalid will now return an "HTTP 400 Bad Request" instead of an "HTTP 404 Not Found", which is why this is potentially a breaking change.

Tests have also been updated accordingly.