### PR TITLE
Replace deprecated ObjectID with ObjectId

### DIFF
--- a/data/fixture/development/results.js
+++ b/data/fixture/development/results.js
@@ -14,13 +14,13 @@
 // along with Pa11y Webservice.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
-const {ObjectID} = require('mongodb');
+const {ObjectId} = require('mongodb');
 const day = (1000 * 60 * 60 * 24);
 
 module.exports = [
 	{
-		_id: new ObjectID('5238358b06c141d74b000018'),
-		task: new ObjectID('52382f23c0d6c9ac49000004'),
+		_id: new ObjectId('5238358b06c141d74b000018'),
+		task: new ObjectId('52382f23c0d6c9ac49000004'),
 		date: Date.now(),
 		count: {
 			total: 124,
@@ -653,8 +653,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238358b06c141d74b000017'),
-		task: new ObjectID('52382f08c0d6c9ac49000003'),
+		_id: new ObjectId('5238358b06c141d74b000017'),
+		task: new ObjectId('52382f08c0d6c9ac49000003'),
 		date: Date.now(),
 		count: {
 			total: 114,
@@ -1237,8 +1237,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238358706c141d74b000016'),
-		task: new ObjectID('52382f31c0d6c9ac49000005'),
+		_id: new ObjectId('5238358706c141d74b000016'),
+		task: new ObjectId('52382f31c0d6c9ac49000005'),
 		date: Date.now(),
 		count: {
 			total: 81,
@@ -1656,8 +1656,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238358606c141d74b000015'),
-		task: new ObjectID('52382ef5c0d6c9ac49000002'),
+		_id: new ObjectId('5238358606c141d74b000015'),
+		task: new ObjectId('52382ef5c0d6c9ac49000002'),
 		date: Date.now(),
 		count: {
 			total: 329,
@@ -3315,8 +3315,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238358206c141d74b000014'),
-		task: new ObjectID('52382ec8c0d6c9ac49000001'),
+		_id: new ObjectId('5238358206c141d74b000014'),
+		task: new ObjectId('52382ec8c0d6c9ac49000001'),
 		date: Date.now(),
 		count: {
 			total: 321,
@@ -4934,8 +4934,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238358006c141d74b000013'),
-		task: new ObjectID('52382f4ac0d6c9ac49000006'),
+		_id: new ObjectId('5238358006c141d74b000013'),
+		task: new ObjectId('52382f4ac0d6c9ac49000006'),
 		date: Date.now(),
 		count: {
 			total: 5,
@@ -4973,8 +4973,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238355206c141d74b000012'),
-		task: new ObjectID('52382f08c0d6c9ac49000003'),
+		_id: new ObjectId('5238355206c141d74b000012'),
+		task: new ObjectId('52382f08c0d6c9ac49000003'),
 		date: Date.now() - day,
 		count: {
 			total: 114,
@@ -5557,8 +5557,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238355106c141d74b000011'),
-		task: new ObjectID('52382f23c0d6c9ac49000004'),
+		_id: new ObjectId('5238355106c141d74b000011'),
+		task: new ObjectId('52382f23c0d6c9ac49000004'),
 		date: Date.now() - day,
 		count: {
 			total: 124,
@@ -6191,8 +6191,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238354d06c141d74b000010'),
-		task: new ObjectID('52382f31c0d6c9ac49000005'),
+		_id: new ObjectId('5238354d06c141d74b000010'),
+		task: new ObjectId('52382f31c0d6c9ac49000005'),
 		date: Date.now() - day,
 		count: {
 			total: 81,
@@ -6610,8 +6610,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238354c06c141d74b00000f'),
-		task: new ObjectID('52382ef5c0d6c9ac49000002'),
+		_id: new ObjectId('5238354c06c141d74b00000f'),
+		task: new ObjectId('52382ef5c0d6c9ac49000002'),
 		date: Date.now() - day,
 		count: {
 			total: 329,
@@ -8269,8 +8269,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238354606c141d74b00000e'),
-		task: new ObjectID('52382ec8c0d6c9ac49000001'),
+		_id: new ObjectId('5238354606c141d74b00000e'),
+		task: new ObjectId('52382ec8c0d6c9ac49000001'),
 		date: Date.now() - day,
 		count: {
 			total: 321,
@@ -9888,8 +9888,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238354506c141d74b00000d'),
-		task: new ObjectID('52382f4ac0d6c9ac49000006'),
+		_id: new ObjectId('5238354506c141d74b00000d'),
+		task: new ObjectId('52382f4ac0d6c9ac49000006'),
 		date: Date.now() - day,
 		count: {
 			total: 5,
@@ -9927,8 +9927,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238351406c141d74b00000c'),
-		task: new ObjectID('52382f08c0d6c9ac49000003'),
+		_id: new ObjectId('5238351406c141d74b00000c'),
+		task: new ObjectId('52382f08c0d6c9ac49000003'),
 		date: Date.now() - (day * 2),
 		count: {
 			total: 114,
@@ -10511,8 +10511,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238351406c141d74b00000b'),
-		task: new ObjectID('52382f23c0d6c9ac49000004'),
+		_id: new ObjectId('5238351406c141d74b00000b'),
+		task: new ObjectId('52382f23c0d6c9ac49000004'),
 		date: Date.now() - (day * 2),
 		count: {
 			total: 124,
@@ -11145,8 +11145,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238351006c141d74b00000a'),
-		task: new ObjectID('52382f31c0d6c9ac49000005'),
+		_id: new ObjectId('5238351006c141d74b00000a'),
+		task: new ObjectId('52382f31c0d6c9ac49000005'),
 		date: Date.now() - (day * 2),
 		count: {
 			total: 81,
@@ -11564,8 +11564,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238351006c141d74b000009'),
-		task: new ObjectID('52382ef5c0d6c9ac49000002'),
+		_id: new ObjectId('5238351006c141d74b000009'),
+		task: new ObjectId('52382ef5c0d6c9ac49000002'),
 		date: Date.now() - (day * 2),
 		count: {
 			total: 329,
@@ -13223,8 +13223,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238350a06c141d74b000008'),
-		task: new ObjectID('52382ec8c0d6c9ac49000001'),
+		_id: new ObjectId('5238350a06c141d74b000008'),
+		task: new ObjectId('52382ec8c0d6c9ac49000001'),
 		date: Date.now() - (day * 2),
 		count: {
 			total: 321,
@@ -14842,8 +14842,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('5238350906c141d74b000007'),
-		task: new ObjectID('52382f4ac0d6c9ac49000006'),
+		_id: new ObjectId('5238350906c141d74b000007'),
+		task: new ObjectId('52382f4ac0d6c9ac49000006'),
 		date: Date.now() - (day * 2),
 		count: {
 			total: 5,
@@ -14881,8 +14881,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523834d906c141d74b000006'),
-		task: new ObjectID('52382f08c0d6c9ac49000003'),
+		_id: new ObjectId('523834d906c141d74b000006'),
+		task: new ObjectId('52382f08c0d6c9ac49000003'),
 		date: Date.now() - (day * 3),
 		count: {
 			total: 114,
@@ -15465,8 +15465,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523834d906c141d74b000005'),
-		task: new ObjectID('52382f23c0d6c9ac49000004'),
+		_id: new ObjectId('523834d906c141d74b000005'),
+		task: new ObjectId('52382f23c0d6c9ac49000004'),
 		date: Date.now() - (day * 3),
 		count: {
 			total: 124,
@@ -16099,8 +16099,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523834d406c141d74b000004'),
-		task: new ObjectID('52382f31c0d6c9ac49000005'),
+		_id: new ObjectId('523834d406c141d74b000004'),
+		task: new ObjectId('52382f31c0d6c9ac49000005'),
 		date: Date.now() - (day * 3),
 		count: {
 			total: 81,
@@ -16518,8 +16518,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523834d306c141d74b000003'),
-		task: new ObjectID('52382ef5c0d6c9ac49000002'),
+		_id: new ObjectId('523834d306c141d74b000003'),
+		task: new ObjectId('52382ef5c0d6c9ac49000002'),
 		date: Date.now() - (day * 3),
 		count: {
 			total: 329,
@@ -18177,8 +18177,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523834cf06c141d74b000002'),
-		task: new ObjectID('52382ec8c0d6c9ac49000001'),
+		_id: new ObjectId('523834cf06c141d74b000002'),
+		task: new ObjectId('52382ec8c0d6c9ac49000001'),
 		date: Date.now() - (day * 3),
 		count: {
 			total: 321,
@@ -19796,8 +19796,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523834cd06c141d74b000001'),
-		task: new ObjectID('52382f4ac0d6c9ac49000006'),
+		_id: new ObjectId('523834cd06c141d74b000001'),
+		task: new ObjectId('52382f4ac0d6c9ac49000006'),
 		date: Date.now() - (day * 3),
 		count: {
 			total: 5,
@@ -19835,8 +19835,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523830dd867caa844a000006'),
-		task: new ObjectID('52382f23c0d6c9ac49000004'),
+		_id: new ObjectId('523830dd867caa844a000006'),
+		task: new ObjectId('52382f23c0d6c9ac49000004'),
 		date: Date.now() - (day * 4),
 		count: {
 			total: 124,
@@ -20469,8 +20469,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523830dc867caa844a000005'),
-		task: new ObjectID('52382f08c0d6c9ac49000003'),
+		_id: new ObjectId('523830dc867caa844a000005'),
+		task: new ObjectId('52382f08c0d6c9ac49000003'),
 		date: Date.now() - (day * 4),
 		count: {
 			total: 114,
@@ -21053,8 +21053,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523830d8867caa844a000004'),
-		task: new ObjectID('52382f31c0d6c9ac49000005'),
+		_id: new ObjectId('523830d8867caa844a000004'),
+		task: new ObjectId('52382f31c0d6c9ac49000005'),
 		date: Date.now() - (day * 4),
 		count: {
 			total: 81,
@@ -21472,8 +21472,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523830d7867caa844a000003'),
-		task: new ObjectID('52382ef5c0d6c9ac49000002'),
+		_id: new ObjectId('523830d7867caa844a000003'),
+		task: new ObjectId('52382ef5c0d6c9ac49000002'),
 		date: Date.now() - (day * 4),
 		count: {
 			total: 329,
@@ -23131,8 +23131,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523830d3867caa844a000002'),
-		task: new ObjectID('52382ec8c0d6c9ac49000001'),
+		_id: new ObjectId('523830d3867caa844a000002'),
+		task: new ObjectId('52382ec8c0d6c9ac49000001'),
 		date: Date.now() - (day * 4),
 		count: {
 			total: 321,
@@ -24750,8 +24750,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('523830d1867caa844a000001'),
-		task: new ObjectID('52382f4ac0d6c9ac49000006'),
+		_id: new ObjectId('523830d1867caa844a000001'),
+		task: new ObjectId('52382f4ac0d6c9ac49000006'),
 		date: Date.now() - (day * 4),
 		count: {
 			total: 5,
@@ -24789,8 +24789,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('52382fb3de8550e749000006'),
-		task: new ObjectID('52382f08c0d6c9ac49000003'),
+		_id: new ObjectId('52382fb3de8550e749000006'),
+		task: new ObjectId('52382f08c0d6c9ac49000003'),
 		date: Date.now() - (day * 5),
 		count: {
 			total: 114,
@@ -25373,8 +25373,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('52382fb1de8550e749000005'),
-		task: new ObjectID('52382f23c0d6c9ac49000004'),
+		_id: new ObjectId('52382fb1de8550e749000005'),
+		task: new ObjectId('52382f23c0d6c9ac49000004'),
 		date: Date.now() - (day * 5),
 		count: {
 			total: 124,
@@ -26007,8 +26007,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('52382faede8550e749000004'),
-		task: new ObjectID('52382ef5c0d6c9ac49000002'),
+		_id: new ObjectId('52382faede8550e749000004'),
+		task: new ObjectId('52382ef5c0d6c9ac49000002'),
 		date: Date.now() - (day * 5),
 		count: {
 			total: 329,
@@ -27666,8 +27666,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('52382facde8550e749000003'),
-		task: new ObjectID('52382f31c0d6c9ac49000005'),
+		_id: new ObjectId('52382facde8550e749000003'),
+		task: new ObjectId('52382f31c0d6c9ac49000005'),
 		date: Date.now() - (day * 5),
 		count: {
 			total: 81,
@@ -28085,8 +28085,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('52382fa7de8550e749000002'),
-		task: new ObjectID('52382f4ac0d6c9ac49000006'),
+		_id: new ObjectId('52382fa7de8550e749000002'),
+		task: new ObjectId('52382f4ac0d6c9ac49000006'),
 		date: Date.now() - (day * 5),
 		count: {
 			total: 5,
@@ -28124,8 +28124,8 @@ module.exports = [
 		]
 	},
 	{
-		_id: new ObjectID('52382fa6de8550e749000001'),
-		task: new ObjectID('52382ec8c0d6c9ac49000001'),
+		_id: new ObjectId('52382fa6de8550e749000001'),
+		task: new ObjectId('52382ec8c0d6c9ac49000001'),
 		date: Date.now() - (day * 5),
 		count: {
 			total: 321,
@@ -29743,8 +29743,8 @@ module.exports = [
 		]
 	},
 	{
-		id: new ObjectID('52457f470dcedad0b6000006'),
-		task: new ObjectID('52457e2b135a4b51b4000001'),
+		id: new ObjectId('52457f470dcedad0b6000006'),
+		task: new ObjectId('52457e2b135a4b51b4000001'),
 		date: Date.now(),
 		count: {
 			total: 165,

--- a/data/fixture/development/tasks.js
+++ b/data/fixture/development/tasks.js
@@ -14,53 +14,53 @@
 // along with Pa11y Webservice.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
-const {ObjectID} = require('mongodb');
+const {ObjectId} = require('mongodb');
 
 module.exports = [
 	{
-		_id: new ObjectID('52382f4ac0d6c9ac49000006'),
+		_id: new ObjectId('52382f4ac0d6c9ac49000006'),
 		ignore: [],
 		name: 'BBC World News',
 		standard: 'Section508',
 		url: 'http://www.bbc.co.uk/news/world/'
 	},
 	{
-		_id: new ObjectID('52382ec8c0d6c9ac49000001'),
+		_id: new ObjectId('52382ec8c0d6c9ac49000001'),
 		ignore: [],
 		name: 'NPG Home',
 		standard: 'WCAG2AA',
 		url: 'http://www.nature.com/'
 	},
 	{
-		_id: new ObjectID('52382ef5c0d6c9ac49000002'),
+		_id: new ObjectId('52382ef5c0d6c9ac49000002'),
 		ignore: [],
 		name: 'NPG Home',
 		standard: 'WCAG2AAA',
 		url: 'http://www.nature.com/'
 	},
 	{
-		_id: new ObjectID('52382f31c0d6c9ac49000005'),
+		_id: new ObjectId('52382f31c0d6c9ac49000005'),
 		ignore: [],
 		name: 'GitHub Home',
 		standard: 'WCAG2A',
 		url: 'https://github.com/'
 	},
 	{
-		_id: new ObjectID('52382f23c0d6c9ac49000004'),
+		_id: new ObjectId('52382f23c0d6c9ac49000004'),
 		ignore: [],
 		name: 'Nature On GitHub',
 		standard: 'WCAG2A',
 		url: 'https://github.com/nature'
 	},
 	{
-		_id: new ObjectID('52382f08c0d6c9ac49000003'),
+		_id: new ObjectId('52382f08c0d6c9ac49000003'),
 		ignore: [],
 		name: 'GOV.UK Home',
 		standard: 'WCAG2AA',
 		url: 'https://www.gov.uk/'
 	},
 	{
-		_id: new ObjectID('52457e2b135a4b51b4000001'),
+		_id: new ObjectId('52457e2b135a4b51b4000001'),
 		ignore: [
 			'WCAG2AA.Principle3.Guideline3_2.3_2_1.G107',
 			'WCAG2AA.Principle2.Guideline2_4.2_4_4.H77,H78,H79,H80,H81',
@@ -72,7 +72,7 @@ module.exports = [
 		url: 'https://twitter.com/'
 	},
 	{
-		_id: new ObjectID('52458167acc00c15b8000001'),
+		_id: new ObjectId('52458167acc00c15b8000001'),
 		ignore: [],
 		name: 'pa11y',
 		standard: 'WCAG2AA',

--- a/data/fixture/test/results.js
+++ b/data/fixture/test/results.js
@@ -14,13 +14,13 @@
 // along with Pa11y Webservice.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
-const {ObjectID} = require('mongodb');
+const {ObjectId} = require('mongodb');
 const day = (1000 * 60 * 60 * 24);
 
 module.exports = [
 	{
-		_id: new ObjectID('def000000000000000000001'),
-		task: new ObjectID('abc000000000000000000001'),
+		_id: new ObjectId('def000000000000000000001'),
+		task: new ObjectId('abc000000000000000000001'),
 		date: Date.now(),
 		count: {
 			error: 1,
@@ -31,8 +31,8 @@ module.exports = [
 		results: ['foo', 'bar']
 	},
 	{
-		_id: new ObjectID('def000000000000000000002'),
-		task: new ObjectID('abc000000000000000000002'),
+		_id: new ObjectId('def000000000000000000002'),
+		task: new ObjectId('abc000000000000000000002'),
 		date: Date.now() - (day * 4),
 		count: {
 			error: 1,
@@ -43,8 +43,8 @@ module.exports = [
 		results: ['foo', 'bar']
 	},
 	{
-		_id: new ObjectID('def000000000000000000003'),
-		task: new ObjectID('abc000000000000000000001'),
+		_id: new ObjectId('def000000000000000000003'),
+		task: new ObjectId('abc000000000000000000001'),
 		date: Date.now() - (day * 7),
 		count: {
 			error: 1,
@@ -55,8 +55,8 @@ module.exports = [
 		results: ['foo', 'bar']
 	},
 	{
-		_id: new ObjectID('def000000000000000000004'),
-		task: new ObjectID('abc000000000000000000002'),
+		_id: new ObjectId('def000000000000000000004'),
+		task: new ObjectId('abc000000000000000000002'),
 		date: Date.now() - (day * 28),
 		count: {
 			error: 1,
@@ -67,8 +67,8 @@ module.exports = [
 		results: ['foo', 'bar']
 	},
 	{
-		_id: new ObjectID('def000000000000000000005'),
-		task: new ObjectID('abc000000000000000000002'),
+		_id: new ObjectId('def000000000000000000005'),
+		task: new ObjectId('abc000000000000000000002'),
 		date: (new Date('2013-01-01')).getTime(),
 		count: {
 			error: 1,
@@ -79,8 +79,8 @@ module.exports = [
 		results: ['foo', 'bar']
 	},
 	{
-		_id: new ObjectID('def000000000000000000006'),
-		task: new ObjectID('abc000000000000000000002'),
+		_id: new ObjectId('def000000000000000000006'),
+		task: new ObjectId('abc000000000000000000002'),
 		date: (new Date('2013-01-05')).getTime(),
 		count: {
 			error: 1,
@@ -91,8 +91,8 @@ module.exports = [
 		results: ['foo', 'bar']
 	},
 	{
-		_id: new ObjectID('def000000000000000000007'),
-		task: new ObjectID('abc000000000000000000001'),
+		_id: new ObjectId('def000000000000000000007'),
+		task: new ObjectId('abc000000000000000000001'),
 		date: (new Date('2013-01-06')).getTime(),
 		count: {
 			error: 1,
@@ -103,8 +103,8 @@ module.exports = [
 		results: ['foo', 'bar']
 	},
 	{
-		_id: new ObjectID('def000000000000000000008'),
-		task: new ObjectID('abc000000000000000000002'),
+		_id: new ObjectId('def000000000000000000008'),
+		task: new ObjectId('abc000000000000000000002'),
 		date: (new Date('2013-01-08')).getTime(),
 		count: {
 			error: 1,

--- a/data/fixture/test/tasks.js
+++ b/data/fixture/test/tasks.js
@@ -14,11 +14,11 @@
 // along with Pa11y Webservice.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
-const {ObjectID} = require('mongodb');
+const {ObjectId} = require('mongodb');
 
 module.exports = [
 	{
-		_id: new ObjectID('abc000000000000000000001'),
+		_id: new ObjectId('abc000000000000000000001'),
 		name: 'NPG Home',
 		url: 'nature.com',
 		timeout: 30000,
@@ -28,21 +28,21 @@ module.exports = [
 		ignore: ['foo', 'bar']
 	},
 	{
-		_id: new ObjectID('abc000000000000000000002'),
+		_id: new ObjectId('abc000000000000000000002'),
 		name: 'NPG Home',
 		url: 'nature.com',
 		timeout: 30000,
 		standard: 'WCAG2AAA'
 	},
 	{
-		_id: new ObjectID('abc000000000000000000003'),
+		_id: new ObjectId('abc000000000000000000003'),
 		name: 'Nature News',
 		url: 'nature.com/news',
 		timeout: 30000,
 		standard: 'Section508'
 	},
 	{
-		_id: new ObjectID('abc000000000000000000004'),
+		_id: new ObjectId('abc000000000000000000004'),
 		name: 'Z Integration Test',
 		url: 'http://localhost:8132',
 		timeout: 30000,

--- a/model/result.js
+++ b/model/result.js
@@ -19,7 +19,7 @@
 /* eslint new-cap: 'off' */
 'use strict';
 
-const {ObjectID} = require('mongodb');
+const {ObjectId} = require('mongodb');
 
 // Result model
 module.exports = function(app, callback) {
@@ -35,8 +35,8 @@ module.exports = function(app, callback) {
 				if (!newResult.date) {
 					newResult.date = Date.now();
 				}
-				if (newResult.task && !(newResult.task instanceof ObjectID)) {
-					newResult.task = ObjectID(newResult.task);
+				if (newResult.task && !(newResult.task instanceof ObjectId)) {
+					newResult.task = ObjectId(newResult.task);
 				}
 				return collection.insertOne(newResult)
 					.then(result => {
@@ -69,7 +69,7 @@ module.exports = function(app, callback) {
 					}
 				};
 				if (opts.task) {
-					filter.task = ObjectID(opts.task);
+					filter.task = ObjectId(opts.task);
 				}
 
 				const prepare = opts.full ? model.prepareForFullOutput : model.prepareForOutput;
@@ -96,9 +96,9 @@ module.exports = function(app, callback) {
 			getById(id, full) {
 				const prepare = (full ? model.prepareForFullOutput : model.prepareForOutput);
 				try {
-					id = new ObjectID(id);
+					id = new ObjectId(id);
 				} catch (error) {
-					console.error('ObjectID generation failed.', error.message);
+					console.error('ObjectId generation failed.', error.message);
 					return null;
 				}
 				return collection.findOne({_id: id})
@@ -123,13 +123,13 @@ module.exports = function(app, callback) {
 			// Delete results for a single task
 			deleteByTaskId(id) {
 				try {
-					id = new ObjectID(id);
+					id = new ObjectId(id);
 				} catch (error) {
-					console.error('ObjectID generation failed.', error.message);
+					console.error('ObjectId generation failed.', error.message);
 					return null;
 				}
 
-				return collection.deleteMany({task: ObjectID(id)})
+				return collection.deleteMany({task: ObjectId(id)})
 					.catch(error => {
 						console.error(`model:result:deleteByTaskId failed, with id: ${id}`);
 						console.error(error.message);
@@ -141,16 +141,16 @@ module.exports = function(app, callback) {
 				const prepare = (opts.full ? model.prepareForFullOutput : model.prepareForOutput);
 
 				try {
-					id = new ObjectID(id);
-					task = new ObjectID(task);
+					id = new ObjectId(id);
+					task = new ObjectId(task);
 				} catch (error) {
-					console.error('ObjectID generation failed.', error.message);
+					console.error('ObjectId generation failed.', error.message);
 					return null;
 				}
 
 				return collection.findOne({
-					_id: ObjectID(id),
-					task: ObjectID(task)
+					_id: ObjectId(id),
+					task: ObjectId(task)
 				})
 					.then(result => {
 						if (result) {

--- a/model/task.js
+++ b/model/task.js
@@ -20,7 +20,7 @@
 'use strict';
 
 const {grey} = require('kleur');
-const {ObjectID} = require('mongodb');
+const {ObjectId} = require('mongodb');
 const pa11y = require('pa11y');
 
 // Task model
@@ -71,13 +71,13 @@ module.exports = function(app, callback) {
 			// Get a task by ID
 			getById: function(id) {
 				try {
-					id = new ObjectID(id);
+					id = new ObjectId(id);
 				} catch (error) {
-					console.error('ObjectID generation failed.', error.message);
+					console.error('ObjectId generation failed.', error.message);
 					return null;
 				}
 
-				return collection.findOne({_id: ObjectID(id)})
+				return collection.findOne({_id: ObjectId(id)})
 					.then(task => {
 						return model.prepareForOutput(task);
 					})
@@ -92,9 +92,9 @@ module.exports = function(app, callback) {
 			editById: function(id, edits) {
 				const idString = id;
 				try {
-					id = new ObjectID(id);
+					id = new ObjectId(id);
 				} catch (error) {
-					console.error('ObjectID generation failed.', error.message);
+					console.error('ObjectId generation failed.', error.message);
 					return null;
 				}
 				const now = Date.now();
@@ -116,7 +116,7 @@ module.exports = function(app, callback) {
 					taskEdits.headers = model.sanitizeHeaderInput(edits.headers);
 				}
 
-				return collection.updateOne({_id: ObjectID(id)}, {$set: taskEdits})
+				return collection.updateOne({_id: ObjectId(id)}, {$set: taskEdits})
 					.then(updateCount => {
 						if (updateCount < 1) {
 							return 0;
@@ -146,9 +146,9 @@ module.exports = function(app, callback) {
 							return 0;
 						}
 						if (Array.isArray(task.annotations)) {
-							return model.collection.updateMany({_id: ObjectID(id)}, {$push: {annotations: annotation}});
+							return model.collection.updateMany({_id: ObjectId(id)}, {$push: {annotations: annotation}});
 						}
-						return model.collection.updateMany({_id: ObjectID(id)}, {$set: {annotations: [annotation]}});
+						return model.collection.updateMany({_id: ObjectId(id)}, {$set: {annotations: [annotation]}});
 
 					})
 					.catch(error => {
@@ -161,12 +161,12 @@ module.exports = function(app, callback) {
 			// Delete a task by ID
 			deleteById: function(id) {
 				try {
-					id = new ObjectID(id);
+					id = new ObjectId(id);
 				} catch (error) {
-					console.error('ObjectID generation failed.', error.message);
+					console.error('ObjectId generation failed.', error.message);
 					return null;
 				}
-				return collection.deleteOne({_id: ObjectID(id)})
+				return collection.deleteOne({_id: ObjectId(id)})
 					.then(result => {
 						return result ? result.deletedCount : null;
 					})

--- a/test/integration/create-task.js
+++ b/test/integration/create-task.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const assert = require('proclaim');
-const {ObjectID} = require('mongodb');
+const {ObjectId} = require('mongodb');
 
 describe('POST /tasks', function() {
 
@@ -316,7 +316,7 @@ describe('POST /tasks', function() {
 
 		it('should add the new task to the database', async function() {
 			const task = await this.app.model.task.collection.findOne({
-				_id: new ObjectID(this.last.response.body.id)
+				_id: new ObjectId(this.last.response.body.id)
 			});
 			assert.isDefined(task);
 			assert.deepEqual(task.headers, newTask.headers);
@@ -357,7 +357,7 @@ describe('POST /tasks', function() {
 
 		it('should add the new task to the database', async function() {
 			const task = await this.app.model.task.collection.findOne({
-				_id: new ObjectID(this.last.response.body.id)
+				_id: new ObjectId(this.last.response.body.id)
 			});
 			assert.isDefined(task);
 			assert.deepEqual(task.headers, {


### PR DESCRIPTION
[Version 4.1.2](https://github.com/mongodb/node-mongodb-native/blob/main/HISTORY.md#412-2021-09-14) of the mongodb client deprecates the use of `ObjectID`, and there's a chance this will be removed in the future. The suggested alternative is to use `ObjectId`.

This replaces all instances of `ObjectID` with `ObjectId` so we'll have an easier path upgrading to v4 of the mongodb client.

Edit: please note this PR is against `next` where the work for the upcoming v5 is temporarily going.