### PR TITLE
Upgrade Hapi to latest so this works with Node 16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
           - node-version: 12.x
             lint: true # Linter is run only once to shorten the total build time
           - node-version: 14.x
+          - node-version: 16.x
 
     steps:
       - name: Checkout code from ${{ github.repository }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-webservice",
-  "version": "3.2.1",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -81,308 +81,278 @@
       }
     },
     "@hapi/accept": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
-      "integrity": "sha512-soThGB+QMgfxlh0Vzhzlf3ZOEOPk5biEwcOXhkF0Eedqx8VnhGiggL9UYHrIsOb1rUg3Be3K8kp0iDL2wbVSOQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
+      "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
-    "@hapi/address": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
-    },
     "@hapi/ammo": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.2.tgz",
-      "integrity": "sha512-ej9OtFmiZv1qr45g1bxEZNGyaR4jRpyMxU6VhbxjaYThymvOwsyIsUKMZnP5Qw2tfYFuwqCJuIBHGpeIbdX9gQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/b64": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
-      "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/boom": {
-      "version": "7.4.11",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-      "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/bounce": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.2.tgz",
-      "integrity": "sha512-3bnb1AlcEByFZnpDIidxQyw1Gds81z/1rSqlx4bIEE+wUN0ATj0D49B5cE1wGocy90Rp/de4tv7GjsKd5RQeew==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "^8.3.1"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/bourne": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
+      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
     },
     "@hapi/call": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.3.tgz",
-      "integrity": "sha512-5DfWpMk7qZiYhvBhM5oUiT4GQ/O8a2rFR121/PdwA/eZ2C1EsuD547ZggMKAR5bZ+FtxOf0fdM20zzcXzq2mZA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/catbox": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.3.tgz",
-      "integrity": "sha512-kN9hXO4NYyOHW09CXiuj5qW1syc/0XeVOBsNNk0Tz89wWNQE5h21WF+VsfAw3uFR8swn/Wj3YEVBnWqo82m/JQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x",
-        "@hapi/podium": "3.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/podium": "4.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/catbox-memory": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
-      "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+      "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/content": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.1.tgz",
-      "integrity": "sha512-3TWvmwpVPxFSF3KBjKZ8yDqIKKZZIm7VurDSweYpXYENZrJH3C1hd1+qEQW9wQaUaI76pPBLGrXl6I3B7i3ipA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
       "requires": {
-        "@hapi/boom": "7.x.x"
+        "@hapi/boom": "9.x.x"
       }
     },
     "@hapi/cryptiles": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
-      "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
       "requires": {
-        "@hapi/boom": "7.x.x"
+        "@hapi/boom": "9.x.x"
       }
     },
     "@hapi/file": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
-      "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ=="
-    },
-    "@hapi/formula": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
-      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
     },
     "@hapi/hapi": {
-      "version": "18.4.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.1.tgz",
-      "integrity": "sha512-9HjVGa0Z4Qv9jk9AVoUdJMQLA+KuZ+liKWyEEkVBx3e3H1F0JM6aGbPkY9jRfwsITBWGBU2iXazn65SFKSi/tg==",
+      "version": "20.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.2.tgz",
+      "integrity": "sha512-crhU6TIKt7QsksWLYctDBAXogk9PYAm7UzdpETyuBHC2pCa6/+B5NykiOVLG/3FCIgHo/raPVtan8bYtByHORQ==",
       "requires": {
-        "@hapi/accept": "^3.2.4",
-        "@hapi/ammo": "^3.1.2",
-        "@hapi/boom": "7.x.x",
-        "@hapi/bounce": "1.x.x",
-        "@hapi/call": "^5.1.3",
-        "@hapi/catbox": "10.x.x",
-        "@hapi/catbox-memory": "4.x.x",
-        "@hapi/heavy": "6.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "15.x.x",
-        "@hapi/mimos": "4.x.x",
-        "@hapi/podium": "3.x.x",
-        "@hapi/shot": "4.x.x",
-        "@hapi/somever": "2.x.x",
-        "@hapi/statehood": "6.x.x",
-        "@hapi/subtext": "^6.1.3",
-        "@hapi/teamwork": "3.x.x",
-        "@hapi/topo": "3.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "15.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
-          "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
-          "requires": {
-            "@hapi/address": "2.x.x",
-            "@hapi/bourne": "1.x.x",
-            "@hapi/hoek": "8.x.x",
-            "@hapi/topo": "3.x.x"
-          }
-        }
+        "@hapi/accept": "^5.0.1",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/call": "^8.0.0",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "^5.0.0",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/mimos": "^6.0.0",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/somever": "^3.0.0",
+        "@hapi/statehood": "^7.0.4",
+        "@hapi/subtext": "^7.0.3",
+        "@hapi/teamwork": "^5.1.1",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/validate": "^1.1.1"
       }
     },
     "@hapi/heavy": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.2.tgz",
-      "integrity": "sha512-PY1dCCO6dsze7RlafIRhTaGeyTgVe49A/lSkxbhKGjQ7x46o/OFf7hLiRqTCDh3atcEKf6362EaB3+kTUbCsVA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/hoek": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
     },
     "@hapi/iron": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
-      "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
       "requires": {
-        "@hapi/b64": "4.x.x",
-        "@hapi/boom": "7.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "8.x.x"
-      }
-    },
-    "@hapi/joi": {
-      "version": "16.1.8",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-      "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-      "requires": {
-        "@hapi/address": "^2.1.2",
-        "@hapi/formula": "^1.2.0",
-        "@hapi/hoek": "^8.2.4",
-        "@hapi/pinpoint": "^1.0.2",
-        "@hapi/topo": "^3.1.3"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/mimos": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
-      "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
       "requires": {
-        "@hapi/hoek": "8.x.x",
+        "@hapi/hoek": "9.x.x",
         "mime-db": "1.x.x"
       }
     },
     "@hapi/nigel": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
-      "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
       "requires": {
-        "@hapi/hoek": "8.x.x",
-        "@hapi/vise": "3.x.x"
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/vise": "^4.0.0"
       }
     },
     "@hapi/pez": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.2.tgz",
-      "integrity": "sha512-8zSdJ8cZrJLFldTgwjU9Fb1JebID+aBCrCsycgqKYe0OZtM2r3Yv3aAwW5z97VsZWCROC1Vx6Mdn4rujh5Ktcg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
       "requires": {
-        "@hapi/b64": "4.x.x",
-        "@hapi/boom": "7.x.x",
-        "@hapi/content": "^4.1.1",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/nigel": "3.x.x"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/nigel": "4.x.x"
       }
     },
-    "@hapi/pinpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
-      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
-    },
     "@hapi/podium": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.3.tgz",
-      "integrity": "sha512-QJlnYLEYZWlKQ9fSOtuUcpANyoVGwT68GA9P0iQQCAetBK0fI+nbRBt58+aMixoifczWZUthuGkNjqKxgPh/CQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+      "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
       "requires": {
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/shot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.2.tgz",
-      "integrity": "sha512-6LeHLjvsq/bQ0R+fhEyr7mqExRGguNTrxFZf5DyKe3CK6pNabiGgYO4JVFaRrLZ3JyuhkS0fo8iiRE2Ql2oA/A==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
       "requires": {
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/somever": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
-      "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
+      "integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
       "requires": {
-        "@hapi/bounce": "1.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/statehood": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.2.tgz",
-      "integrity": "sha512-pYXw1x6npz/UfmtcpUhuMvdK5kuOGTKcJNfLqdNptzietK2UZH5RzNJSlv5bDHeSmordFM3kGItcuQWX2lj2nQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
+      "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/bounce": "1.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/iron": "5.x.x",
-        "@hapi/joi": "16.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/iron": "6.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/subtext": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.3.tgz",
-      "integrity": "sha512-qWN6NbiHNzohVcJMeAlpku/vzbyH4zIpnnMPMPioQMwIxbPFKeNViDCNI6fVBbMPBiw/xB4FjqiJkRG5P9eWWg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+      "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/content": "^4.1.1",
-        "@hapi/file": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/pez": "^4.1.2",
-        "@hapi/wreck": "15.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/file": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/pez": "^5.0.1",
+        "@hapi/wreck": "17.x.x"
       }
     },
     "@hapi/teamwork": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
-      "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg=="
     },
     "@hapi/topo": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "requires": {
-        "@hapi/hoek": "^8.3.0"
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/validate": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
       }
     },
     "@hapi/vise": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
-      "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/wreck": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
-      "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
+      "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@humanwhocodes/config-array": {
@@ -1716,9 +1686,9 @@
       "optional": true
     },
     "mime-db": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.27",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "bugs": "https://github.com/pa11y/webservice/issues",
   "license": "GPL-3.0",
   "dependencies": {
-    "@hapi/hapi": "~18.4.1",
+    "@hapi/hapi": "~20.2.2",
     "async": "~3.2.2",
     "cron": "~1.8.2",
     "joi": "~17.4.2",

--- a/route/task.js
+++ b/route/task.js
@@ -17,7 +17,7 @@
 'use strict';
 
 const {green, grey, red} = require('kleur');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const {isValidAction} = require('pa11y');
 
 // Routes relating to individual tasks
@@ -89,7 +89,7 @@ module.exports = function(app) {
 		},
 		options: {
 			validate: {
-				query: {},
+				query: Joi.object({}),
 				payload: Joi.object({
 					name: Joi.string().required(),
 					timeout: Joi.number().integer(),
@@ -127,7 +127,7 @@ module.exports = function(app) {
 		},
 		options: {
 			validate: {
-				query: {},
+				query: Joi.object({}),
 				payload: false
 			}
 		}
@@ -165,7 +165,7 @@ module.exports = function(app) {
 		},
 		options: {
 			validate: {
-				query: {}
+				query: Joi.object({})
 			}
 		}
 	});

--- a/route/tasks.js
+++ b/route/tasks.js
@@ -17,7 +17,7 @@
 'use strict';
 
 const _ = require('underscore');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const {isValidAction} = require('pa11y');
 
 // Routes relating to all tasks
@@ -88,7 +88,7 @@ module.exports = function(app) {
 		},
 		options: {
 			validate: {
-				query: {},
+				query: Joi.object({}),
 				payload: Joi.object({
 					name: Joi.string().required(),
 					timeout: Joi.number().integer(),


### PR DESCRIPTION
Hapi v20.1.2 (yes, really) adds support for Node.js v16, we were still on Hapi v18 which is why the project failed to build and run with recent versions of node.

Hapi 19 introduces a new behaviour where it will complain if the app doesn't define a default joi schema compiler and a validator doesn't use `Joi.object()` explicitly. I've chosen to add `Joi.object()` to every field where it was missing instead of defining a default schema compiler as I believe this will make it easier to detect similar errors in the future.

This also fixes an issue where the wrong Joi dependency was being used in `route/task.js` and `route/tasks.js` - these were requiring '@hapi/joi' v16 (which was installed as a dependency of Hapi itself) rather than the 'joi' v17 that we are installing ourselves. This worked fine until I upgraded '@hapi/hapi', which now doesn't require '@hapi/joi' any more.

This commit also adds Node v16 to the test matrix.