### PR TITLE
Log the number of workers defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ app(config, (error, initialisedApp) => {
 	console.log(grey('uri:      %s'), initialisedApp.server.info.uri);
 	console.log(grey('database: %s'), dbConnectionString);
 	console.log(grey('cron:     %s'), config.cron);
+	console.log(grey('workers:  %s'), config.numWorkers);
 
 	if (error) {
 		console.error('');


### PR DESCRIPTION
The option to configure the number of workers was added in v3.2.0, but the option is not logged at startup, so it's impossible to know for sure if webservice is using the right setting or not.