### PR TITLE
Include runner configuration per task and include global configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,7 +26,8 @@ if (fs.existsSync(jsonPath)) {
 		port: Number(env('PORT', jsonConfig.port)),
 		cron: env('CRON', jsonConfig.cron),
 		chromeLaunchConfig: jsonConfig.chromeLaunchConfig || {},
-		numWorkers: jsonConfig.numWorkers || 2
+		numWorkers: jsonConfig.numWorkers || 2,
+		runners: jsonConfig.runners || ['htmlcs']
 	};
 } else {
 	module.exports = {
@@ -35,7 +36,8 @@ if (fs.existsSync(jsonPath)) {
 		port: Number(env('PORT', '3000')),
 		cron: env('CRON', false),
 		chromeLaunchConfig: {},
-		numWorkers: Number(env('NUM_WORKERS', '2'))
+		numWorkers: Number(env('NUM_WORKERS', '2')),
+		runners: ['htmlcs']
 	};
 }
 

--- a/config/development.sample.json
+++ b/config/development.sample.json
@@ -7,5 +7,6 @@
 		"args": [
 			"--no-sandbox"
 		]
-	}
+	},
+	"runners": ["axe", "htmlcs"]
 }

--- a/config/production.sample.json
+++ b/config/production.sample.json
@@ -3,5 +3,6 @@
 	"host": "0.0.0.0",
 	"port": 3000,
 	"cron": "0 30 0 * * *",
-	"chromeLaunchConfig": {}
+	"chromeLaunchConfig": {},
+	"runners": []
 }

--- a/config/test.sample.json
+++ b/config/test.sample.json
@@ -2,5 +2,6 @@
 	"database": "mongodb://localhost/pa11y-webservice-test",
 	"host": "0.0.0.0",
 	"port": 3000,
-	"chromeLaunchConfig": {}
+	"chromeLaunchConfig": {},
+	"runners": ["htmlcs"]
 }

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ app(config, (error, initialisedApp) => {
 	console.log(grey('database: %s'), dbConnectionString);
 	console.log(grey('cron:     %s'), config.cron);
 	console.log(grey('workers:  %s'), config.numWorkers);
+	console.log(grey('runners:  %s'), config.runners);
 
 	if (error) {
 		console.error('');

--- a/model/task.js
+++ b/model/task.js
@@ -104,7 +104,8 @@ module.exports = function(app, callback) {
 					wait: parseInt(edits.wait, 10),
 					actions: edits.actions,
 					username: edits.username,
-					password: edits.password
+					password: edits.password,
+					runners: edits.runners
 				};
 				if (edits.ignore) {
 					taskEdits.ignore = edits.ignore;
@@ -190,6 +191,7 @@ module.exports = function(app, callback) {
 						actions: task.actions || [],
 						chromeLaunchConfig: app.config.chromeLaunchConfig || {},
 						headers: task.headers || {},
+						runners: task.runners || app.config.runners,
 						log: {
 							debug: model.pa11yLog(task.id),
 							error: model.pa11yLog(task.id),
@@ -238,7 +240,8 @@ module.exports = function(app, callback) {
 					wait: (task.wait ? parseInt(task.wait, 10) : 0),
 					standard: task.standard,
 					ignore: task.ignore || [],
-					actions: task.actions || []
+					actions: task.actions || [],
+					runners: task.runners || app.config.runners
 				};
 				if (task.annotations) {
 					output.annotations = task.annotations;

--- a/route/task.js
+++ b/route/task.js
@@ -100,6 +100,7 @@ module.exports = function(app) {
 					username: Joi.string().allow(''),
 					password: Joi.string().allow(''),
 					hideElements: Joi.string().allow(''),
+					runners: Joi.array().items(Joi.string()),
 					headers: [
 						Joi.string().allow(''),
 						Joi.object().pattern(/.*/, Joi.string().allow(''))

--- a/route/tasks.js
+++ b/route/tasks.js
@@ -105,6 +105,7 @@ module.exports = function(app) {
 					ignore: Joi.array(),
 					actions: Joi.array().items(Joi.string()),
 					hideElements: Joi.string().allow(''),
+					runners: Joi.array().items(Joi.string()),
 					headers: [
 						Joi.string().allow(''),
 						Joi.object().pattern(/.*/, Joi.string().allow(''))

--- a/test/integration/create-task.js
+++ b/test/integration/create-task.js
@@ -28,7 +28,8 @@ describe('POST /tasks', function() {
 				url: 'nature.com',
 				timeout: '30000',
 				standard: 'WCAG2AA',
-				ignore: ['foo', 'bar']
+				ignore: ['foo', 'bar'],
+				runners: ['axe']
 			};
 
 			const request = {
@@ -60,12 +61,14 @@ describe('POST /tasks', function() {
 			assert.strictEqual(this.last.body.url, newTask.url);
 			assert.strictEqual(this.last.body.standard, newTask.standard);
 			assert.deepEqual(this.last.body.ignore, newTask.ignore || []);
+			assert.deepEqual(this.last.body.runners, newTask.runners);
 		});
 
 	});
 
 	describe('with valid JSON and HTTP basic user authentication', function() {
 		let newTask;
+		const defaultRunners = ['htmlcs'];
 
 		beforeEach(function(done) {
 			newTask = {
@@ -108,6 +111,7 @@ describe('POST /tasks', function() {
 			assert.strictEqual(this.last.body.password, newTask.password);
 			assert.strictEqual(this.last.body.standard, newTask.standard);
 			assert.deepEqual(this.last.body.ignore, newTask.ignore || []);
+			assert.deepEqual(this.last.body.runners, defaultRunners);
 			assert.deepEqual(this.last.body.hideElements, newTask.hideElements);
 		});
 

--- a/test/integration/edit-task-by-id.js
+++ b/test/integration/edit-task-by-id.js
@@ -38,6 +38,7 @@ describe('PATCH /tasks/{id}', function() {
 					actions: [
 						'click element body'
 					],
+					runners: ['run', 'sprint'],
 					comment: 'Just changing some stuff, you know'
 				};
 				const request = {
@@ -86,6 +87,11 @@ describe('PATCH /tasks/{id}', function() {
 			it('should update the task\'s actions in the database', async function() {
 				const task = await this.app.model.task.getById('abc000000000000000000001');
 				assert.deepEqual(task.actions, taskEdits.actions);
+			});
+
+			it('should update the task\'s associated runners in the database', async function() {
+				const task = await this.app.model.task.getById('abc000000000000000000001');
+				assert.deepEqual(task.runners, taskEdits.runners);
 			});
 
 			it('should add an annotation for the edit to the task', async function() {
@@ -232,6 +238,38 @@ describe('PATCH /tasks/{id}', function() {
 			assert.notDeepEqual(task.actions, taskEdits.actions);
 		});
 
+	});
+
+	describe('with invalid runners during edit', function() {
+		let taskEdits;
+
+		const defaultRunners = ['htmlcs'];
+
+		beforeEach(function(done) {
+			// Runners need to be strings
+			taskEdits = {
+				runners: [
+					1,
+					2
+				]
+			};
+			const request = {
+				method: 'PATCH',
+				endpoint: 'tasks/abc000000000000000000001',
+				body: taskEdits
+			};
+			this.navigate(request, done);
+		});
+
+		it('should send a 400 status', function() {
+			assert.strictEqual(this.last.status, 400);
+		});
+
+		it('should not update the task in the database and continue to be default', async function() {
+			const task = await this.app.model.task.getById('abc000000000000000000001');
+			assert.notDeepEqual(task.runners, taskEdits.runners);
+			assert.deepEqual(task.runners, defaultRunners);
+		});
 	});
 
 	describe('with valid but non-existent task ID', function() {

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -31,7 +31,8 @@ describe('config', () => {
 		numWorkers: 2,
 		chromeLaunchConfig: {
 			field: 'value'
-		}
+		},
+		runners: ['htmlcs']
 	};
 
 	before(() => {
@@ -67,6 +68,7 @@ describe('config', () => {
 				assert.strictEqual(config.port, mockConfig.port);
 				assert.strictEqual(config.cron, mockConfig.cron);
 				assert.strictEqual(config.numWorkers, mockConfig.numWorkers);
+				assert.deepEqual(config.runners, mockConfig.runners);
 				assert.deepEqual(config.chromeLaunchConfig, mockConfig.chromeLaunchConfig);
 			});
 
@@ -93,6 +95,7 @@ describe('config', () => {
 				assert.strictEqual(config.port, 2000);
 				assert.strictEqual(config.cron, mockConfig.cron);
 				assert.strictEqual(config.numWorkers, mockConfig.numWorkers);
+				assert.deepEqual(config.runners, mockConfig.runners);
 				assert.deepEqual(config.chromeLaunchConfig, mockConfig.chromeLaunchConfig);
 			});
 		});


### PR DESCRIPTION
- Initial attempt at including runner configurations into pa11y-webservices
- This patch include per-task runner configuration with the `POST /tasks` request including the `runners: []` entries
- This patch allows edits of the runner configuration with the `PATCH` requests with the `runners: []` entries.
- The global service can be configured with the `runners: []` in `config/` as the default.

Firstly thank you to the pa11y community for such an amazing project. In this PR, I am requesting feedback in the attempt of addressing #88. It has been a long time since #127 was proposed and it hasn't had any recent updates on it. I apologize in advance if this might be overstepping on the work done in the previous patch. Enabling this setting was needed and helpful for a project I've been doing recently and I would like to get feedback from the community on if this design is preferable. This would definitely result in changes in the `pa11y-dashboard`. It'd also be interesting to see if `pa11y` can expose a `pa11y.availableRunners()` of some sort.

Signed-off-by: Sudheesh Singanamalla <sudheesh@cs.washington.edu>