### PR TITLE
Version 4.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 4.2.0 (pending)
+## 4.2.0 (2023-11-13)
 
-* Pending
+* Update to `pa11y@~6.2.3` from `~6.1.0`
+* Other dependency updates above patch level:
+  * `hapi@~20.3` from `~20.2`
+  * `cron@~2.4` from `~1.8`
+  * `joi@~17.11` from `~17.4`
+  * `mongodb@~3.7` from `~3.6`
 
 ## 4.1.0 (2022-04-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.2.0 (pending)
+
+* Pending
+
 ## 4.1.0 (2022-04-25)
 
 * Add support for Node v16 via upgrading Hapi to the latest version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-webservice",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-webservice",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "engines": {
     "node": ">=12"
   },


### PR DESCRIPTION
ℹ️ [Diff of changes](https://github.com/pa11y/pa11y-webservice/compare/4.1.0..main) since `4.1.0`. See also [milestone 4.2](https://github.com/pa11y/pa11y-webservice/milestone/3).

This PR also drops the publishing workflow, which isn't tested yet in CI, back to use `ubuntu-20.04`, same as the testing workflow.