### PR TITLE
Decouple integration tests from JSON file, undo error code change

### DIFF
--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -22,7 +22,7 @@ const request = require('request');
 const config = {
 	database: process.env.DATABASE || 'mongodb://127.0.0.1/pa11y-webservice-test',
 	host: process.env.HOST || '0.0.0.0',
-	port: process.env.PORT || 3000
+	port: Number(process.env.PORT) || 3000
 };
 
 before(function(done) {

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -22,7 +22,7 @@ const request = require('request');
 const config = {
 	database: process.env.DATABASE || 'mongodb://127.0.0.1/pa11y-webservice-test',
 	host: process.env.HOST || '0.0.0.0',
-	port: process.env.PORT_FOR_SERVICE_UNDER_TEST || 3000
+	port: process.env.PORT || 3000
 };
 
 before(function(done) {

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -15,19 +15,23 @@
 'use strict';
 
 const app = require('../../app');
-const config = require('../../config/test.json');
 const createNavigator = require('./helper/navigate');
 const loadFixtures = require('../../data/fixture/load');
 const request = require('request');
 
-// Run before all tests
+const config = {
+	database: process.env.DATABASE || 'mongodb://127.0.0.1/pa11y-webservice-test',
+	host: process.env.HOST || '0.0.0.0',
+	port: process.env.PORT_FOR_SERVICE_UNDER_TEST || 3000
+};
+
 before(function(done) {
-	this.baseUrl = `http://localhost:${config.port}/`;
+	this.baseUrl = `http://${config.host}:${config.port}/`;
 	this.app = null;
 	this.last = {};
 	this.navigate = createNavigator(this.baseUrl, this.last);
 
-	assertTestAppIsRunning(this.baseUrl, () => {
+	assertServiceIsAvailable(this.baseUrl, () => {
 		config.dbOnly = true;
 		app(config, (error, initialisedApp) => {
 			this.app = initialisedApp;
@@ -36,13 +40,11 @@ before(function(done) {
 	});
 });
 
-// Run after each test
 afterEach(done => {
 	loadFixtures('test', config, done);
 });
 
-// Check that the test application is running, and exit if not
-function assertTestAppIsRunning(baseUrl, done) {
+function assertServiceIsAvailable(baseUrl, done) {
 	request(baseUrl, error => {
 		if (error) {
 			console.error(`Error: Test app not started. NODE_ENV was ${process.env.NODE_ENV}; run with \`NODE_ENV=test node index.js\``);

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -20,8 +20,6 @@ const createNavigator = require('./helper/navigate');
 const loadFixtures = require('../../data/fixture/load');
 const request = require('request');
 
-const errorCodeForNoService = 2;
-
 // Run before all tests
 before(function(done) {
 	this.baseUrl = `http://localhost:${config.port}/`;
@@ -48,7 +46,7 @@ function assertTestAppIsRunning(baseUrl, done) {
 	request(baseUrl, error => {
 		if (error) {
 			console.error(`Error: Test app not started. NODE_ENV was ${process.env.NODE_ENV}; run with \`NODE_ENV=test node index.js\``);
-			process.exit(errorCodeForNoService);
+			process.exit();
 		}
 		done();
 	});

--- a/test/integration/startup.js
+++ b/test/integration/startup.js
@@ -14,28 +14,21 @@
 // along with Pa11y Webservice.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
+const util = require('util');
 const assert = require('proclaim');
-const config = require('../../config/test.json');
 const app = require('../../app');
 
-describe('pa11y-service startup', function() {
+const config = {
+	database: process.env.DATABASE || 'mongodb://127.0.0.1/pa11y-webservice-test',
+	host: process.env.HOST || '0.0.0.0',
+	port: process.env.PORT_FOR_SPINUP_TEST || 3010
+};
 
-	it('should start the service and call the callback', done => {
-		const modifiedConfig = {
-			database: config.database,
-			host: config.host,
-			port: config.port + 10
-		};
+describe('pa11y-webservice lifecycle', function() {
+	it('should start and stop the service', async () => {
+		const service = await util.promisify(app)(config);
+		assert.isDefined(service);
 
-		app(modifiedConfig, (error, webservice) => {
-			assert.isNull(error);
-			assert.notStrictEqual(webservice, undefined);
-
-			webservice.server.stop();
-
-			done();
-		});
+		await service.server.stop();
 	});
 });
-
-

--- a/test/integration/startup.js
+++ b/test/integration/startup.js
@@ -21,7 +21,7 @@ const app = require('../../app');
 const config = {
 	database: process.env.DATABASE || 'mongodb://127.0.0.1/pa11y-webservice-test',
 	host: process.env.HOST || '0.0.0.0',
-	port: process.env.PORT_FOR_SPINUP_TEST || 3010
+	port: Number(process.env.PORT_FOR_SPINUP_TEST) || 3010
 };
 
 describe('pa11y-webservice lifecycle', function() {


### PR DESCRIPTION
This PR:

- undoes the error code change in `assertTestAppIsRunning` from #147
- tests that the service will stop pleasantly
- decouples the integration tests' spinup test, and setup for other tests, from the transient JSON file `config/test.json`
    - spinup test port can also now be supplied separately using `PORT_FOR_SPINUP_TEST`