### PR TITLE
Use this project's own dependency `lodash.groupby`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.1 (2023-11-15)
+
+* Fix bug in naming when requiring `lodash.groupby`
+
 ## 4.3.0 (2023-11-14)
 
 * Set dependency `pa11y` to `^6.2.3` from `~6.2.3` to permit minor level upgrades to take place at installation time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pa11y-webservice",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pa11y-webservice",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@hapi/hapi": "~20.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-webservice",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "engines": {
     "node": ">=12"
   },

--- a/route/tasks.js
+++ b/route/tasks.js
@@ -16,7 +16,7 @@
 /* eslint camelcase: 'off' */
 'use strict';
 
-const groupBy = require('lodash/groupby');
+const groupBy = require('lodash.groupby');
 const Joi = require('joi');
 const {isValidAction} = require('pa11y');
 


### PR DESCRIPTION
Will be released as `v4.3.1`.

---

This PR fixes a typo: `lodash/groupby` becomes `lodash.groupby`.  This was discovered by running `npm ci` on a project which installs it as a dependency, possibly due to full `lodash` being smuggled in otherwise:

- https://github.com/pa11y/pa11y-dashboard/pull/318
